### PR TITLE
create-play: add support for older node versions

### DIFF
--- a/plop-templates/component.hbs
+++ b/plop-templates/component.hbs
@@ -1,5 +1,3 @@
-
-import { useLocation } from 'react-router-dom';
 import { getPlayById } from 'meta/play-meta-util';
 
 import PlayHeader from 'common/playlists/PlayHeader';

--- a/plopfile.js
+++ b/plopfile.js
@@ -1,3 +1,7 @@
+String.prototype.replaceAll = String.prototype.replaceAll || function(string, replaced) {
+  return this.replace(new RegExp(string, 'g'), replaced);
+};
+
 module.exports = plop => {
   plop.setHelper('trim', str => str.trim());
   plop.setHelper('removeAllSpaces', str => str.replaceAll(/\s/g,''));


### PR DESCRIPTION
# Description

I have fixed this bug by adding a custom `.replaceAll` method to the string.prototype if not supported.

Fixes #46 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have created a new play with Node 14.19.1 and it works

![image](https://user-images.githubusercontent.com/62352949/164068862-637a0d65-d1a9-4abd-9c27-0df7fca7143d.png)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
