### PR TITLE
Update Meta tags to use explicit URLs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,61 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="ReactPlay" />
-    <meta property="og:image:type" content="image/png" />
-    <meta property="og:image:width" content="400" />
-    <meta property="og:image:height" content="300" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta
-      name="description"
-      content="ReactPlay is an open-source application to learn, create and
-      share ReactJS projects with the developer community."
-      data-react-helmet="true"
-    />
-    <meta
-      property="og:description"
-      content="ReactPlay is an open-source application to learn, create and
-    share ReactJS projects with the developer community."
-      data-react-helmet="true"
-    />
-    <meta
-      property="og:title"
-      content="ReactPlay - One app to learn, create, and share ReactJS projects."
-      data-react-helmet="true"
-    />
-    <meta
-      property="og:image"
-      content="/og-image.png"
-      these
-      to
-      public
-      data-react-helmet="true"
-    />
-    <meta
-      property="og:image:alt"
-      content="Start React Code Arena with ReactPlay"
-      data-react-helmet="true"
-    />
-    <meta name="twitter:site" content="@ReactPlayIO" data-react-helmet="true" />
-    <meta
-      name="twitter:title"
-      content="ReactPlay - One app to learn, create, and share ReactJS projects."
-      data-react-helmet="true"
-    />
-    <meta
-      name="twitter:description"
-      content="ReactPlay is an open-source application to learn, create and
-    share ReactJS projects with the developer community."
-      data-react-helmet="true"
-    />
-    <meta
-      name="twitter:image"
-      content="/og-image.png"
-      these
-      to
-      public
-      data-react-helmet="true"
-    />
+    <meta name="twitter:site" content="@ReactPlayIO" />
 
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/src/common/playlists/PlayMeta.jsx
+++ b/src/common/playlists/PlayMeta.jsx
@@ -10,7 +10,8 @@ function PlayMeta({ id, name, description, path, cover, component }) {
   } else {
     try {
       // If not, try finding the cover.png in the play's folder
-      metaImage = `https://reactplay.io${require(`../../plays/${playFolder}/cover.png`)}`;
+      metaImage = `https://reactplay.io${require(`../../plays/${playFolder}/cover.png`)}`; // It seems that
+      // some platforms such as Twitter need full, explicit URL's to display images correctly
     } catch {
       // If no image is available, cover stays as undefined
       console.log("No cover available.");

--- a/src/common/playlists/PlayMeta.jsx
+++ b/src/common/playlists/PlayMeta.jsx
@@ -10,7 +10,7 @@ function PlayMeta({ id, name, description, path, cover, component }) {
   } else {
     try {
       // If not, try finding the cover.png in the play's folder
-      metaImage = require(`../../plays/${playFolder}/cover.png`);
+      metaImage = `https://reactplay.io${require(`../../plays/${playFolder}/cover.png`)}`;
     } catch {
       // If no image is available, cover stays as undefined
       console.log("No cover available.");

--- a/src/meta/DefMeta.jsx
+++ b/src/meta/DefMeta.jsx
@@ -37,11 +37,6 @@ function DefMeta() {
         data-react-helmet="true"
       />
       <meta
-        name="twitter:site"
-        content="@ReactPlayIO"
-        data-react-helmet="true"
-      />
-      <meta
         name="twitter:title"
         content="ReactPlay - One app to learn, create, and share ReactJS projects."
         data-react-helmet="true"

--- a/src/meta/DefMeta.jsx
+++ b/src/meta/DefMeta.jsx
@@ -28,7 +28,7 @@ function DefMeta() {
       />
       <meta
         property="og:image"
-        content="/og-image.png" // React should default these to public
+        content="https://reactplay.io/og-image.png" // React should default these to public
         data-react-helmet="true"
       />
       <meta
@@ -49,7 +49,7 @@ function DefMeta() {
       />
       <meta
         name="twitter:image"
-        content="/og-image.png" // React should default these to public
+        content="https://reactplay.io/og-image.png" // React should default these to public
         data-react-helmet="true"
       />
     </Helmet>


### PR DESCRIPTION
# Description

I noticed a few minutes ago that the meta tags we use don't work properly on some sites/apps.
This PR makes it so that the image URLs used for the meta tages are explicit(includes the full URL). This change was made because some sites do not behave as expected with the old URLs we were using, causing images to not appear on them. Changing it to an explicit URL got the results we wanted though!

I did not open an issue for this PR as it was a simple change but I can do so if you need me to!

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested this using external browser extensions and by pushing to Vercel and testing link embeds for various Plays.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Notes:

This should be the final fix to the meta tag problem! It's been fun figuring out how to implement this feature, thank you for the amazing opportunity! :)
