### PR TITLE
fix content overflow of tag list

### DIFF
--- a/src/common/playlists/playlist.css
+++ b/src/common/playlists/playlist.css
@@ -225,7 +225,9 @@
 .play-details .play-details-header .header-leftcol-action .action:focus .icon {
     fill: rgba(var(--color-neutral-90-rgb), 0.8);
 }
-
+.play-details .play-details-header .list-tags{
+    flex-wrap: wrap;
+}
 @media screen and (max-width: 1172px) {
     .play-details .play-details-header .header-leftcol-action {
         padding-top: .16rem;


### PR DESCRIPTION
# Description

Fixes issue of content overflowing when there are more than 5 tags in the play page while the screen width is less than 435px.


Fixes #122

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested via Dev tools.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
