### PR TITLE
fix: clock flicker & color contrast

### DIFF
--- a/src/plays/clock/clock.css
+++ b/src/plays/clock/clock.css
@@ -1,8 +1,32 @@
 .counter .value {
-  background: #f7f705;
-  padding: 1rem;
-  font-size: 3.5rem;
+  background: linear-gradient(0deg, #b9740b,rgb(173, 134, 16));
+  color: #ddd;
+  width: 280px;
+  padding: .5rem;
+  letter-spacing: 1px;
+  font-weight: bolder;
+  font-size: 2.5rem;
   border-radius: 5px;
-  text-shadow: 2px 2px 5px red;
-  box-shadow: 10px 10px #aea103;
+  text-shadow: 1px 1px 3px #111;
+  box-shadow: 5px 5px #ffa500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (min-width: 550px){
+  .counter .value {  
+    width: 450px;
+    padding: 1rem;
+    letter-spacing: 2px;
+    font-size: 4rem;
+    border-radius: 5px;
+    text-shadow: 2px 2px 5px #111;
+    box-shadow: 10px 10px #ffa500;
+  }
+}
+
+.counter .value  span{
+  font-family: monospace;
+
 }


### PR DESCRIPTION
Hi! @atapas I have fixed three things for **Clock Play**:
 1. Clock flickering by adding width and font-family
 2. Better background and font color contrast. 
 3. Responsive design for the small screen.
 - Current Clock
   ![Clock](https://user-images.githubusercontent.com/69510006/166294391-10356265-8805-41ef-9d46-2acd1fe57d80.JPG)

 - New Design
 ![Clock](https://user-images.githubusercontent.com/69510006/166294377-7a554253-54c3-440e-949f-992ce800f9f9.JPG)

Please review this contribution. 

Thanks