### PR TITLE
Close modal when clicked on overlay or 'Escape' button is pressed

### DIFF
--- a/src/common/modal/index.jsx
+++ b/src/common/modal/index.jsx
@@ -1,11 +1,25 @@
+import { useEffect } from "react";
 import ReactDOM from "react-dom";
 import { GoCheck, GoX } from "react-icons/go";
 
 const Modal =({ title, show, onClose, onSubmit, children, cname })=> {
+  useEffect(() => {
+    const close = (e) => {
+      // e.keyCode is deprecated: developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode. So I've used e.key === 'Escape' instead, for better international keyboard support. 
+      if(e.key === 'Escape') {
+        onClose();
+      }
+    }
+    window.addEventListener('keydown', close)
+    return () => window.removeEventListener('keydown', close)
+},[])
+
   if (!show) return null;
+
+
   return ReactDOM.createPortal(
     <>
-      <div className="modal-overlay"></div>
+      <div className="modal-overlay" onClick={ onClose }></div>
       <div className={`modal-${cname}`}>
         <div className={`modal-${cname}-header`}>
           <h2 className="modal-title">{ title }</h2>


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
**Issue[feature request]**: The filter modal should be closed when **Esc** button is pressed or when the modal container is clicked.

Fixes #195

## Type of change
**solution**: Added onClose method on modal-overlay which sets useState showModal's value to false. For binding escape button, I've added a event listner in useEffect which checks whether **Esc** button is pressed or not and if pressed it sets showModal to false.

Please delete options that are not relevant.

- [X ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I've done some manual testing and it's working fine.

# Checklist:

- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes
- [ X] Any dependent changes have been merged and published in downstream modules
